### PR TITLE
Add Content-Type to the request headers

### DIFF
--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -83,8 +83,9 @@ async function call<T>(
             method,
             headers: api.token
                 ? {
-                      Authorization: `Bearer ${api.token}`,
-                  }
+                    Authorization: `Bearer ${api.token}`,
+                    'Content-Type': 'application/json',
+                }
                 : undefined,
             query: query(options.query),
             body: options.body && JSON.stringify(options.body),

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "ava",
-    "prepare" : "npm run build"
+    "test": "ava"
   },
   "author": "Aaron Sky <aaronsky@skyaaron.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "ava"
+    "test": "ava",
+    "prepare" : "npm run build"
   },
   "author": "Aaron Sky <aaronsky@skyaaron.com>",
   "license": "MIT",


### PR DESCRIPTION
POST requests are failing due to missing `Content-Type` header. This is likely not an elegant solution –may want to refactor the api logic to allow passing in additional headers selectively– but it seems to resolve the issues I was seeing.